### PR TITLE
feat(webapp): use methods instead of setters for header and background colors

### DIFF
--- a/.changeset/clean-beers-scream.md
+++ b/.changeset/clean-beers-scream.md
@@ -1,0 +1,5 @@
+---
+"@twa.js/sdk": patch
+---
+
+Use methods instead of setters for header and background colors

--- a/packages/sdk/__tests__/components/WebApp/WebApp.ts
+++ b/packages/sdk/__tests__/components/WebApp/WebApp.ts
@@ -10,7 +10,7 @@ describe('components', () => {
             const webApp = new WebApp('', '', 'bg_color', '#000000', jest.fn());
 
             expect(webApp.colorScheme).toBe('dark');
-            webApp.backgroundColor = '#ffffff';
+            webApp.setBackgroundColor('#ffffff');
             expect(webApp.colorScheme).toBe('light');
           });
         });
@@ -22,7 +22,7 @@ describe('components', () => {
             const webApp = new WebApp('', '', 'bg_color', '#000000', postEvent);
 
             expect(postEvent).toHaveBeenCalledTimes(0);
-            webApp.backgroundColor = '#ffaabb';
+            webApp.setBackgroundColor('#ffaabb');
             expect(postEvent).toHaveBeenCalledTimes(1);
             expect(postEvent).toHaveBeenCalledWith('web_app_set_background_color', { color: '#ffaabb' });
           });
@@ -33,7 +33,7 @@ describe('components', () => {
 
             webApp.on('backgroundColorChanged', listener);
             expect(listener).toHaveBeenCalledTimes(0);
-            webApp.backgroundColor = '#ffaacc';
+            webApp.setBackgroundColor('#ffaacc');
             expect(listener).toHaveBeenCalledTimes(1);
             expect(listener).toHaveBeenCalledWith('#ffaacc');
           });
@@ -45,7 +45,7 @@ describe('components', () => {
             const webApp = new WebApp('', '', 'bg_color', '#000000', postEvent);
 
             expect(postEvent).toHaveBeenCalledTimes(0);
-            webApp.headerColor = 'secondary_bg_color';
+            webApp.setHeaderColor('secondary_bg_color');
             expect(postEvent).toHaveBeenCalledTimes(1);
             expect(postEvent).toHaveBeenCalledWith('web_app_set_header_color', { color_key: 'secondary_bg_color' });
           });
@@ -56,7 +56,7 @@ describe('components', () => {
 
             webApp.on('headerColorChanged', listener);
             expect(listener).toHaveBeenCalledTimes(0);
-            webApp.headerColor = 'secondary_bg_color';
+            webApp.setHeaderColor('secondary_bg_color');
             expect(listener).toHaveBeenCalledTimes(1);
             expect(listener).toHaveBeenCalledWith('secondary_bg_color');
           });
@@ -71,14 +71,14 @@ describe('components', () => {
               webApp.on('backgroundColorChanged', listener);
 
               expect(listener).toHaveBeenCalledTimes(0);
-              webApp.backgroundColor = '#aaddcc';
+              webApp.setBackgroundColor('#aaddcc');
               expect(listener).toHaveBeenCalledTimes(1);
 
               webApp.off('backgroundColorChanged', listener);
               listener.mockClear();
 
               expect(listener).toHaveBeenCalledTimes(0);
-              webApp.backgroundColor = '#ffaaaa';
+              webApp.setBackgroundColor('#ffaaaa');
               expect(listener).toHaveBeenCalledTimes(0);
             });
           });
@@ -91,14 +91,14 @@ describe('components', () => {
               webApp.on('headerColorChanged', listener);
 
               expect(listener).toHaveBeenCalledTimes(0);
-              webApp.headerColor = 'secondary_bg_color';
+              webApp.setHeaderColor('secondary_bg_color');
               expect(listener).toHaveBeenCalledTimes(1);
 
               webApp.off('headerColorChanged', listener);
               listener.mockClear();
 
               expect(listener).toHaveBeenCalledTimes(0);
-              webApp.headerColor = 'bg_color';
+              webApp.setHeaderColor('bg_color');
               expect(listener).toHaveBeenCalledTimes(0);
             });
           });

--- a/packages/sdk/src/components/WebApp/WebApp.ts
+++ b/packages/sdk/src/components/WebApp/WebApp.ts
@@ -62,25 +62,6 @@ export class WebApp
   }
 
   /**
-   * Updates current application background color.
-   * FIXME: Has no effect on desktop, works incorrectly in Android.
-   *  Issues:
-   *  https://github.com/Telegram-Web-Apps/twa.js/issues/9
-   *  https://github.com/Telegram-Web-Apps/twa.js/issues/8
-   * @param color - new color.
-   */
-  set backgroundColor(color: RGB) {
-    this.#postEvent('web_app_set_background_color', { color });
-
-    if (this.#backgroundColor === color) {
-      return;
-    }
-
-    this.#backgroundColor = color;
-    this.#ee.emit('backgroundColorChanged', color);
-  }
-
-  /**
    * Returns current application color scheme. This value is
    * computed based on the current background color.
    */
@@ -100,25 +81,6 @@ export class WebApp
    */
   get headerColor(): HeaderColorKey {
     return this.#headerColor;
-  }
-
-  /**
-   * Updates current application header color.
-   * FIXME: Has no effect on desktop, works incorrectly on Android.
-   *  Issues:
-   *  https://github.com/Telegram-Web-Apps/twa.js/issues/9
-   *  https://github.com/Telegram-Web-Apps/twa.js/issues/8
-   * @param color - settable color key.
-   */
-  set headerColor(color: HeaderColorKey) {
-    this.#postEvent('web_app_set_header_color', { color_key: color });
-
-    if (this.#headerColor === color) {
-      return;
-    }
-
-    this.#headerColor = color;
-    this.#ee.emit('headerColorChanged', color);
   }
 
   /**
@@ -288,6 +250,44 @@ export class WebApp
       throw new Error(`Passed data has incorrect size: ${size}`);
     }
     this.#postEvent('web_app_data_send', { data });
+  }
+
+  /**
+   * Updates current application header color.
+   * FIXME: Has no effect on desktop, works incorrectly on Android.
+   *  Issues:
+   *  https://github.com/Telegram-Web-Apps/twa.js/issues/9
+   *  https://github.com/Telegram-Web-Apps/twa.js/issues/8
+   * @param color - settable color key.
+   */
+  setHeaderColor(color: HeaderColorKey) {
+    this.#postEvent('web_app_set_header_color', { color_key: color });
+
+    if (this.#headerColor === color) {
+      return;
+    }
+
+    this.#headerColor = color;
+    this.#ee.emit('headerColorChanged', color);
+  }
+
+  /**
+   * Updates current application background color.
+   * FIXME: Has no effect on desktop, works incorrectly in Android.
+   *  Issues:
+   *  https://github.com/Telegram-Web-Apps/twa.js/issues/9
+   *  https://github.com/Telegram-Web-Apps/twa.js/issues/8
+   * @param color - new color.
+   */
+  setBackgroundColor(color: RGB) {
+    this.#postEvent('web_app_set_background_color', { color });
+
+    if (this.#backgroundColor === color) {
+      return;
+    }
+
+    this.#backgroundColor = color;
+    this.#ee.emit('backgroundColorChanged', color);
   }
 
   /**


### PR DESCRIPTION
Use methods instead of setters for header and background colors